### PR TITLE
Drop loop kwarg from async_timeout.timeout

### DIFF
--- a/pysochain/__init__.py
+++ b/pysochain/__init__.py
@@ -26,7 +26,7 @@ class ChainSo(object):
             _BASE_URL, 'get_address_balance', self.network, self.address)
 
         try:
-            with async_timeout.timeout(5, loop=self._loop):
+            with async_timeout.timeout(5):
                 response = yield from self._session.get(url)
 
             _LOGGER.debug("Response from chain.so: %s", response.status)


### PR DESCRIPTION
- async_timeout 4.0.0 drops the loop= kwarg and will fail if its passed